### PR TITLE
Fixed getTransformToElement error

### DIFF
--- a/lib/joint.js
+++ b/lib/joint.js
@@ -17370,6 +17370,11 @@ if (typeof exports === 'object') {
     };
     // SVG version.
     var SVGversion = '1.1';
+    
+    // make sure we have polyfill if missing as per https://github.com/huei90/snap.svg.zpd/issues/57
+    SVGElement.prototype.getTransformToElement = SVGElement.prototype.getTransformToElement || function(elem) {
+      return elem.getScreenCTM().inverse().multiply(this.getScreenCTM());
+    };
 
     // Create SVG element.
     // -------------------


### PR DESCRIPTION
Chrome has removed getTransformToElement from SVGElement

Resulting in the error: "Uncaught TypeError: this.node.getTransformToElement is not a function" when called.

Fix taken from:
https://github.com/clientIO/joint/issues/203
